### PR TITLE
feat: use package name in tool descriptions for generated MCP server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,23 @@ program
     'Output directory for the bundled server',
     'dist',
   )
+  .option(
+    '-t, --toolName <name>',
+    'Name of the tool/package/library being documented (used in tool descriptions)',
+  )
   .action(async (options) => {
     try {
       console.log(`Scanning for files matching: ${options.docs}`);
       console.log(`Generating server named: ${options.packageName}`);
-      await generateServer(options.docs, options.packageName, options.outDir);
+      if (options.toolName) {
+        console.log(`Using tool name: ${options.toolName}`);
+      }
+      await generateServer(
+        options.docs,
+        options.packageName,
+        options.outDir,
+        options.toolName,
+      );
       console.log(
         `✅ MCP server successfully generated in ${options.outDir}/index.js`,
       );


### PR DESCRIPTION
This PR implements the enhancement described in issue #8.

**Changes:**

- Added a new command-line option `--toolName` to specify the name of the tool/package/library being documented
- Modified the generated server code to include this tool name in the descriptions for each tool
- Updated the tool descriptions to follow the specified format

**Example Usage:**
```
docs-to-mcp-cli --docs "docs/**/*.md" --packageName @lala-gilder/testing-library --toolName "Lala.Gilder.TestingLibrary"
```

Closes #8