### PR TITLE
Optimize Fuse.js configuration for search_docs tool

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -66,16 +66,21 @@ const SERVER_NAME = '${packageName}';
 const SERVER_VERSION = '1.0.0';
 const TOOL_NAME = '${toolName || ''}'; // Injected by the CLI
 const FUSE_OPTIONS = {
-  keys: ['content'], // Search within the document content
-  threshold: 0.1,    // Perfect match required (was 0.1)
-  includeScore: true, // Include score in results
-  includeMatches: true, // Include match information for highlighting
-  minMatchCharLength: 4, // Increased minimum match length (was 3)
-  findAllMatches: true,
-  ignoreLocation: false, // Consider location for more precise matching
+  keys: [
+    { name: 'content', weight: 1.0 }, // Primary search target: file content
+    { name: 'name', weight: 0.5 }     // Secondary target: file path/name, lower weight
+  ],
+  threshold: 0.4,          // Loosen threshold for better fuzzy matching
+  includeScore: true,      // Include score in results
+  includeMatches: true,    // Include match information for highlighting
+  minMatchCharLength: 3,   // Slightly lower minimum length for better matches
+  findAllMatches: true,    // Find all matches for comprehensive results
+  ignoreLocation: true,    // Search anywhere, don't penalize location
   useExtendedSearch: true, // Enable extended search for better pattern matching
-  distance: 20,     // Reduced maximum edit distance (was 100)
-  ignoreFieldNorm: true, // Don't penalize for field length
+  ignoreFieldNorm: true,   // Don't penalize for field length
+  shouldSort: true,        // Explicitly sort by score
+  isCaseSensitive: false,  // Case insensitive search
+  ignoreDiacritics: true,  // Ignore diacritics for international text
 };
 const LIST_DOCS_PREVIEW_CHARS = 90;
 const SEARCH_CONTEXT_CHARS = 200; // Characters to show before and after match


### PR DESCRIPTION
Fixes #10

This PR optimizes the Fuse.js configuration for the `search_docs` tool in generated MCP servers to improve search functionality.

Changes:
- Added weighted keys to search both content (weight 1.0) and file paths/names (weight 0.5)
- Loosened threshold from 0.1 to 0.4 for better fuzzy matching
- Reduced minMatchCharLength from 4 to 3
- Set ignoreLocation to true to search anywhere in documents
- Added shouldSort, isCaseSensitive, and ignoreDiacritics options

These changes should significantly improve search results by:
1. Enabling search in both document content and file paths/names
2. Improving fuzzy matching with a more lenient threshold
3. Allowing shorter search terms (3 characters instead of 4)
4. Ignoring location to find matches anywhere in documents
5. Adding case insensitivity and diacritic handling for better international support